### PR TITLE
load angulars main file and let it register angular to window object

### DIFF
--- a/test/js/test-helpers.js
+++ b/test/js/test-helpers.js
@@ -10,11 +10,14 @@ global.window.beforeEach = beforeEach;
 global.window.afterEach = afterEach;
 
 global.navigator = window.navigator = {};
+global.location = window.location;
 
-require('../../bower_components/angular');
+require('../../bower_components/angular/angular');
+
+global.angular = window.angular;
+
 require('../../bower_components/angular-mocks');
 
 global.angular = window.angular;
-global.location = window.location;
 global.inject = global.angular.mock.inject;
 global.ngModule = global.angular.mock.module;


### PR DESCRIPTION
From that point forward everything referring to plain "angular" variable uses the one assigned.
